### PR TITLE
Change n_cycles for shower

### DIFF
--- a/Data/Appliances.py
+++ b/Data/Appliances.py
@@ -397,7 +397,7 @@ set_appliances = \
     "standby_flow": 0, 
     "activity": "shower", 
     "type": "tapping", 
-    "cycle_n": 73, 
+    "cycle_n": 730, 
     "cycle_flow": 8
   }, 
   "WashingMachine": {


### PR DESCRIPTION
Checking Jordan & Vajens, I noticed the number of cycles for a shower should not be 73 cycles per year, but 2/day * 365 days/year i.e. 730 cycles/year.