### PR TITLE
Fix cycle load issue #16 

### DIFF
--- a/Corpus/stats.py
+++ b/Corpus/stats.py
@@ -26,7 +26,7 @@ def get_probability(rnd, prob, p_type='cum'):
 
 def sum_dict(dict_a, dict_b):
     '''
-    Sum the values stored under the same keys in python dictionarys.
+    Sum the values stored under the same keys in python dictionaries.
     '''
     # loop through the keys and sum both values given
     if len(dict_a.keys()) == 0:
@@ -36,7 +36,7 @@ def sum_dict(dict_a, dict_b):
     else:
         sum_dict = dict()
         for key in dict_a.keys():
-            if dict_a[key] == None:
+            if dict_a[key] is None:
                 sum_dict.update({key:None})
             elif key != 'time':
                 sum_dict.update({key:dict_a[key]+dict_b[key]})


### PR DESCRIPTION
This commit should fix the `cycle_load` model in `residential.py`, reported in #16 . However, **calibration** for these types of loads **should still be done** with the new model (updating the `cal` value in `Appliances.py`). 
Also note the model has some assumptions that could be changed, e.g. that the cycle length and delay are constant throughout the year, and that the power is the mean power assigned for that appliance (this could be sampled instead).  