### PR TITLE
Changed delay times of cycle loads to obtain annual demand and cycles

### DIFF
--- a/Corpus/residential.py
+++ b/Corpus/residential.py
@@ -758,11 +758,12 @@ class Equipment(object):
             # define length of cycles (same for entire year, assumed to depend on appliance)
             len_cycle=random.gauss(self.cycle_length, self.cycle_length/10)
             # define duration of break between cycles (same for entire year)
-            delay=random.gauss(self.delay, self.delay/4)
+            delay=random.gauss(self.delay, self.delay/10)
             
             # start as OFF (assumption)
             on=False #is it ON? 
-            left = delay # time left until change of state
+            left = random.gauss(delay/2, delay/4) # time left until change of state (initiate random)
+
                        
             for tl in range(nbin+1): # loop over every minute of the year
                 # if there is time LEFT until change of state, remain as is

--- a/Data/Appliances.py
+++ b/Data/Appliances.py
@@ -11,7 +11,7 @@ set_appliances = \
     "cycle_length": 22, 
     "name": "FridgeFreezer", 
     "consumption": 426.064566552874, 
-    "delay": 44, 
+    "delay": 64, 
     "cal": 0.0501456635736654, 
     "type": "appliance"
   }, 
@@ -126,7 +126,7 @@ set_appliances = \
     "cycle_length": 14, 
     "name": "ChestFreezer", 
     "consumption": 271.131996897283, 
-    "delay": 56, 
+    "delay": 72, 
     "cal": 0.0627277652193313, 
     "type": "appliance"
   }, 
@@ -216,7 +216,7 @@ set_appliances = \
     "cycle_length": 20, 
     "name": "UprightFreezer", 
     "consumption": 315.980898639691, 
-    "delay": 40, 
+    "delay": 66, 
     "cal": 0.0385476720182227, 
     "type": "appliance"
   }, 
@@ -246,7 +246,7 @@ set_appliances = \
     "cycle_length": 18, 
     "name": "Refrigerator", 
     "consumption": 201.820057840835, 
-    "delay": 36, 
+    "delay": 68, 
     "cal": 0.0313068377395511, 
     "type": "appliance"
   }, 


### PR DESCRIPTION
I noticed that for cold appliances, which are cycling loads, using the given cycle length and delay (between cycles) resulted in too many cycles in a year, and consequently too high annual demand (compared to reference from Richardson's CREST model). Assuming that what is more important is the annual consumption, and taking as given inputs the power and cycle length, I adjusted the delay time such that the annual consumption fits the desired one. 
There is still some variation among households taken into account by sampling the cycle length and delay around the mean values. 
This is not the one and only correct way to do it, but I think it's more clean and respects the values given in `Appliances.py`. 

 