### PR TITLE
roundup() with simulate()

### DIFF
--- a/Corpus/__calibrate__.py
+++ b/Corpus/__calibrate__.py
@@ -12,7 +12,6 @@ Updated in March 2020 to include flow calibration, Christina Protopapadaki
 import os
 import numpy as np
 import json
-import cPickle
 import residential
 from Data.Appliances import set_appliances
 from collections import defaultdict
@@ -55,7 +54,6 @@ for j in range(rep):
         if i in range(0,N,10) : print 'Test house '+str(i) + ' created'
         test = residential.Household('Test_'+str(i))
         test.simulate()
-        test.roundUp()
 ###########  to save time & space, don't save individual simulation results       
 #        os.chdir(cwd + '\\Calibration')
 #        test.pickle()
@@ -140,3 +138,4 @@ for k in conv:
 plt.legend(loc='lower right');
 plt.gca().grid()
 plt.show()
+

--- a/Corpus/feeder.py
+++ b/Corpus/feeder.py
@@ -12,7 +12,7 @@ import os
 
 class IDEAS_Feeder(object):
     '''
-    The Community class defines a set of hosueholds.
+    The Community class defines a set of households.
     '''
     
     def __init__(self, name, nBui, path, sh_K=True):
@@ -45,7 +45,6 @@ class IDEAS_Feeder(object):
         for i in range(self.nBui):
             hou = residential.Household(str(self.name)+'_'+str(i))
             hou.simulate()
-            hou.roundUp()
             os.chdir(path)
             hou.pickle()
             os.chdir(cwd)

--- a/Corpus/residential.py
+++ b/Corpus/residential.py
@@ -164,6 +164,7 @@ class Household(object):
         self.__plugload__()
         self.__dhwload__()
         self.__shsetting__()
+        self.roundUp()
 
     def __chronology__(self, year, ndays=None):
         '''
@@ -587,9 +588,13 @@ class Household(object):
         self.QRad = self.r_receptacles['QRad'] + self.r_lighting['QRad']
         self.QCon = self.r_receptacles['QCon'] + self.r_lighting['QCon']
         self.mDHW = self.r_flows['mDHW']
-
+        self.dow = self.dow[0] # only first day of year is interensting to keep (Monday = 0)
+        
         #######################################################################        
         # bring last 4 h to the front so that data starts at midnight
+        self.occ_m = np.roll(self.occ_m,24)
+        self.occ=[np.roll(i,24) for i in self.occ] 
+ 
         self.sh_day = np.roll(self.sh_day,24)
         self.sh_night = np.roll(self.sh_night,24)
         self.sh_bath = np.roll(self.sh_bath,24)

--- a/Corpus/simulation.py
+++ b/Corpus/simulation.py
@@ -58,7 +58,6 @@ def simulate_scenarios(n_scen, ndays):
         family.simulate(2013, ndays)
 
         # aggregate scenarios:
-        family.roundUp()
         elec[i, :] = family.P
         mDHW[i, :] = family.mDHW
 


### PR DESCRIPTION
This pull request adds the 4h shift to the occupancy results `occ` and `occ_m` that can be found in the Household simulation results. Previously only the outputs used in the `feeder` simulation were shifted. 
Additionally, the function `roundUp()`, used to perform this shift, is now executed as part of the `simulate()` function, to guarantee the correct time shifting also when someone simulates independent households and forgets to `roundUp`.  
`roundUp()` joins the main outputs, performs the time shift and also deletes some of the detailed results to clear space, e.g. power results separately for lighting and appliances. Normally the latter are not used, but if required an adaptation of the code should be made. 