### PR TITLE
Fix for occupancy cluster selection issue #32

### DIFF
--- a/Corpus/__calibrate__.py
+++ b/Corpus/__calibrate__.py
@@ -51,7 +51,7 @@ for j in range(rep):
     n.update({'QCon':0}) # annual convective internal heat gains in kWh
     
     for i in range(N):
-        if i in range(0,N,10) : print 'Test house '+str(i) + ' created'
+        print '##############################################Test house '+str(i) + ' created, repetition ' + str(j)
         test = residential.Household('Test_'+str(i))
         test.simulate()
 ###########  to save time & space, don't save individual simulation results       

--- a/Corpus/data.py
+++ b/Corpus/data.py
@@ -30,7 +30,7 @@ def get_clusters(employment, **kwargs):
         emp_i = order.index(employment)
         data = np.loadtxt('Crosstable_Employment_'+key+'.txt', float).T[emp_i]
         rnd = np.random.random()
-        cluster = stats.get_probability(rnd, data[1:], p_type='prob')
+        cluster = stats.get_probability(rnd, data, p_type='prob')
         cluDict.update({key:cluster})
     ##########################################################################
     # and return the final cluster id's

--- a/Corpus/residential.py
+++ b/Corpus/residential.py
@@ -22,17 +22,6 @@ sys.path.append("..")
 from Data.Households import households
 from Data.Appliances import set_appliances
 
-#changes for new cold-appliance fix #######################################
-# Based on 10000 runs, these new values combined with rule-based fix (see in def appliances)
-# lead to the same overall ownership as the original values.
-# We change it here so that the original remain in the Appliances file.
-set_appliances['Refrigerator']['owner']=0.27     # original:  0.430
-set_appliances['FridgeFreezer']['owner']=0.40    # original:  0.651
-set_appliances['ChestFreezer']['owner']=0.19     # original:  0.163
-set_appliances['UprightFreezer']['owner']=0.31   # original:  0.291
-
-####################################################################
-
 class Household(object):
     '''
     The Household class is the main class of StROBe, defining the
@@ -94,6 +83,16 @@ class Household(object):
             '''
             # Loop through all appliances and pick randomly based on the
             # rate of ownership.
+            #changes for new cold-appliance fix #######################################
+            
+            # Based on 10000 runs, these new values combined with rule-based fix below
+            # lead to the same overall ownership as the original values.
+            # We change it here so that the original remain in the Appliances file.
+            set_appliances['Refrigerator']['owner']=0.27     # original:  0.430
+            set_appliances['FridgeFreezer']['owner']=0.40    # original:  0.651
+            set_appliances['ChestFreezer']['owner']=0.19     # original:  0.163
+            set_appliances['UprightFreezer']['owner']=0.31   # original:  0.291
+            
             app_n = []
             for app in set_appliances:
                 if set_appliances[app]['type'] == 'appliance':

--- a/Data/Appliances.py
+++ b/Data/Appliances.py
@@ -3,7 +3,7 @@ set_appliances = \
   "FridgeFreezer": {
     "frad": 0.46, 
     "cycle_power": 190, 
-    "cal": 0.051806018421305826, 
+    "cal": 0.05302278109276634, 
     "standby_power": 0, 
     "owner": 0.651, 
     "cycle_n": 6115.75932851014, 
@@ -18,7 +18,7 @@ set_appliances = \
   "Hob": {
     "frad": 0.3, 
     "cycle_power": 2400, 
-    "cal": 0.03175070290034901, 
+    "cal": 0.035719693342637734, 
     "standby_power": 1, 
     "owner": 0.463, 
     "cycle_n": 417.902007298679, 
@@ -48,7 +48,7 @@ set_appliances = \
   "DVD": {
     "frad": 0.92, 
     "cycle_power": 33.5521973529143, 
-    "cal": 0.057155439054293794, 
+    "cal": 0.05483103394785327, 
     "standby_power": 2, 
     "owner": 0.896, 
     "cycle_n": 1464.26653737683, 
@@ -63,7 +63,7 @@ set_appliances = \
   "Kettle": {
     "frad": 0.17, 
     "cycle_power": 2000, 
-    "cal": 0.00428210999877837, 
+    "cal": 0.004343036279384075, 
     "standby_power": 1, 
     "owner": 0.975, 
     "cycle_n": 1519.82286616642, 
@@ -78,7 +78,7 @@ set_appliances = \
   "Microwave": {
     "frad": 0, 
     "cycle_power": 1250, 
-    "cal": 0.006942215508745606, 
+    "cal": 0.0075533680233228475, 
     "standby_power": 2, 
     "owner": 0.859, 
     "cycle_n": 94.619322407248, 
@@ -93,7 +93,7 @@ set_appliances = \
   "HiFi": {
     "frad": 0.5, 
     "cycle_power": 100, 
-    "cal": 0.006767223582943735, 
+    "cal": 0.0076866474619492284, 
     "standby_power": 9, 
     "owner": 0.9, 
     "cycle_n": 109.425544999843, 
@@ -107,7 +107,7 @@ set_appliances = \
   }, 
   "bathFlow": {
     "cycle_length": 10, 
-    "cal": 0.013417466674299753, 
+    "cal": 0.013959890338716127, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "shower", 
@@ -118,7 +118,7 @@ set_appliances = \
   "ChestFreezer": {
     "frad": 0.46, 
     "cycle_power": 190, 
-    "cal": 0.0650629500412721, 
+    "cal": 0.06346681125456163, 
     "standby_power": 0, 
     "owner": 0.163, 
     "cycle_n": 6115.75932851014, 
@@ -133,7 +133,7 @@ set_appliances = \
   "Fax": {
     "frad": 0.5, 
     "cycle_power": 37, 
-    "cal": 0.0005045780011519894, 
+    "cal": 0.0005413938298533963, 
     "standby_power": 3, 
     "owner": 0.2, 
     "cycle_n": 197.123588348433, 
@@ -148,7 +148,7 @@ set_appliances = \
   "Printer": {
     "frad": 0.67, 
     "cycle_power": 335.2, 
-    "cal": 0.05830171710707319, 
+    "cal": 0.05980888943100479, 
     "standby_power": 4, 
     "owner": 0.665, 
     "cycle_n": 654.875958011369, 
@@ -163,7 +163,7 @@ set_appliances = \
   "PC": {
     "frad": 0.92, 
     "cycle_power": 140.7, 
-    "cal": 0.07129590345417895, 
+    "cal": 0.07499926963830043, 
     "standby_power": 5, 
     "owner": 0.708, 
     "cycle_n": 449.237984776012, 
@@ -193,7 +193,7 @@ set_appliances = \
   "WasherDryer": {
     "frad": 0.0, 
     "cycle_power": 792.034786057663, 
-    "cal": 0.23647183876843642, 
+    "cal": 0.2887586611722148, 
     "standby_power": 1, 
     "owner": 0.153, 
     "cycle_n": 195.906595865545, 
@@ -208,7 +208,7 @@ set_appliances = \
   "UprightFreezer": {
     "frad": 0.46, 
     "cycle_power": 155, 
-    "cal": 0.03905511776780283, 
+    "cal": 0.0436450754889704, 
     "standby_power": 0, 
     "owner": 0.291, 
     "cycle_n": 6115.75932851014, 
@@ -223,7 +223,7 @@ set_appliances = \
   "Vacuum": {
     "frad": 0.5, 
     "cycle_power": 2000, 
-    "cal": 0.11375752750301396, 
+    "cal": 0.13664095138921212, 
     "standby_power": 0, 
     "owner": 0.937, 
     "cycle_n": 110.367597918536, 
@@ -238,7 +238,7 @@ set_appliances = \
   "Refrigerator": {
     "frad": 0.46, 
     "cycle_power": 110, 
-    "cal": 0.03207269461595831, 
+    "cal": 0.03385193315361484, 
     "standby_power": 0, 
     "owner": 0.43, 
     "cycle_n": 6115.75932851014, 
@@ -252,7 +252,7 @@ set_appliances = \
   }, 
   "shortFlow": {
     "cycle_length": 1, 
-    "cal": 0.040730074807358685, 
+    "cal": 0.04098810282302966, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "Presence", 
@@ -263,7 +263,7 @@ set_appliances = \
   "TV1": {
     "frad": 0.65, 
     "cycle_power": 124, 
-    "cal": 0.05681707015543097, 
+    "cal": 0.05468163455408799, 
     "standby_power": 3, 
     "owner": 0.977, 
     "cycle_n": 1464.26653737683, 
@@ -278,7 +278,7 @@ set_appliances = \
   "MusicPlayer": {
     "frad": 0.5, 
     "cycle_power": 15, 
-    "cal": 0.11297568375303375, 
+    "cal": 0.12567928463364575, 
     "standby_power": 2, 
     "owner": 0.9, 
     "cycle_n": 1212.76285809679, 
@@ -293,7 +293,7 @@ set_appliances = \
   "TV3": {
     "frad": 0.65, 
     "cycle_power": 124, 
-    "cal": 0.06130639491655106, 
+    "cal": 0.05511285694231206, 
     "standby_power": 2, 
     "owner": 0.18, 
     "cycle_n": 1521.49596625218, 
@@ -308,7 +308,7 @@ set_appliances = \
   "TV2": {
     "frad": 0.65, 
     "cycle_power": 124, 
-    "cal": 0.05548734860169355, 
+    "cal": 0.05384932384140438, 
     "standby_power": 3, 
     "owner": 0.58, 
     "cycle_n": 1464.26653737683, 
@@ -322,7 +322,7 @@ set_appliances = \
   }, 
   "mediumFlow": {
     "cycle_length": 1, 
-    "cal": 0.01705732845009613, 
+    "cal": 0.01712974547614407, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "Presence", 
@@ -333,7 +333,7 @@ set_appliances = \
   "Iron": {
     "frad": 0.5, 
     "cycle_power": 1000, 
-    "cal": 0.008653833631984364, 
+    "cal": 0.009365414670544862, 
     "standby_power": 0, 
     "owner": 0.9, 
     "cycle_n": 35.4594692107747, 
@@ -348,7 +348,7 @@ set_appliances = \
   "TumbleDryer": {
     "frad": 0.0, 
     "cycle_power": 2500, 
-    "cal": 0.38642772623291605, 
+    "cal": 0.4932231780194472, 
     "standby_power": 1, 
     "owner": 0.416, 
     "cycle_n": 122.072915738278, 
@@ -363,7 +363,7 @@ set_appliances = \
   "DishWasher": {
     "frad": 0.0, 
     "cycle_power": 1130.61224489796, 
-    "cal": 0.0469846606928911, 
+    "cal": 0.045701393607434415, 
     "standby_power": 0, 
     "owner": 0.335, 
     "cycle_n": 241.476395726831, 
@@ -378,7 +378,7 @@ set_appliances = \
   "TVReceiver": {
     "frad": 0.92, 
     "cycle_power": 26.8237423726735, 
-    "cal": 0.055660984197830776, 
+    "cal": 0.0548252897719791, 
     "standby_power": 15, 
     "owner": 0.934, 
     "cycle_n": 1464.26653737683, 
@@ -392,7 +392,7 @@ set_appliances = \
   }, 
   "showerFlow": {
     "cycle_length": 5, 
-    "cal": 0.018995535858652532, 
+    "cal": 0.01979471557132772, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "shower", 
@@ -403,7 +403,7 @@ set_appliances = \
   "WashingMachine": {
     "frad": 0.0, 
     "cycle_power": 405.54347826087, 
-    "cal": 0.23718341992168035, 
+    "cal": 0.2523055679005739, 
     "standby_power": 1, 
     "owner": 0.781, 
     "cycle_n": 195.906595865545, 
@@ -418,7 +418,7 @@ set_appliances = \
   "Oven": {
     "frad": 0.17, 
     "cycle_power": 2125, 
-    "cal": 0.01622864805309982, 
+    "cal": 0.01809465246066292, 
     "standby_power": 3, 
     "owner": 0.616, 
     "cycle_n": 219.792801008503, 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ In [example.py](https://github.com/open-ideas/StROBe/blob/master/example.py) you
 
 ## Revision history
 
+**OCt 1, 2020**
+(See [pull request](https://github.com/open-ideas/StROBe/pull/33) for details.)
+
+- Fixed problem with wrong occupancy cluster selection, in [`Corpus/data.py`](https://github.com/open-ideas/StROBe/blob/master/Corpus/data.py#L33). Now all different occupancy patterns should be correctly represented.
+
 **May 8, 2020**
 (See [pull request](https://github.com/open-ideas/StROBe/pull/31) for details.)
 


### PR DESCRIPTION
Fix for issue #32, namely the wrong selection of occupancy clusters. The problem was in `get_clusters()` of  [`Corpus/data.py`](https://github.com/open-ideas/StROBe/blob/master/Corpus/data.py#L33)
Calibration factors in `Appliances.py` have been updated after 10 runs of 100 buildings, but the differences are very small.