### PR TITLE
Fix for typical week in occupancy issue #34

### DIFF
--- a/Corpus/__test__.py
+++ b/Corpus/__test__.py
@@ -12,7 +12,8 @@ import feeder
 import cPickle
 
 DIR = os.path.dirname(os.path.realpath(__file__))
-os.chdir(os.path.dirname(DIR)+'\\Data')
+path=os.path.dirname(DIR)+'\\Data'
+os.chdir(path)
 
 class EquipmentTest(unittest.TestCase):
     '''
@@ -32,7 +33,7 @@ class HouseholdTest(unittest.TestCase):
         self.assertEqual(test.name, self.name)
         self.assertTrue(len(test.apps)!=0)
         self.assertTrue(len(test.members)!=0)
-        self.assertTrue(len(test.clusters)!=0)
+        self.assertTrue(len(test.clustersList)!=0)
         print '\n'
 
     def test_creation_2(self):
@@ -40,7 +41,7 @@ class HouseholdTest(unittest.TestCase):
         self.assertEqual(test.name, self.name)
         self.assertTrue(len(test.apps)!=0)
         self.assertTrue(len(test.members)!=0)
-        self.assertTrue(len(test.clusters)!=0)
+        self.assertTrue(len(test.clustersList)!=0)
         print '\n'
         
     def test_simulation(self):
@@ -66,7 +67,7 @@ class FeederTest(unittest.TestCase):
         self.name = 'Example'
         
     def test_creation1(self):
-        test = feeder.IDEAS_Feeder(self.name, 2, r'E:\3_PhD\6_Python\Test')
+        test = feeder.IDEAS_Feeder(self.name, 2, path)
         self.assertEqual(test.name, self.name)
         print '\n'
 

--- a/Corpus/simulation.py
+++ b/Corpus/simulation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Simulate demand scenarios at buildings level."""
+"""Simulate demand scenarios at building level, for specific household."""
 
 import numpy as np
 from residential import Household
@@ -11,12 +11,12 @@ def convert_occupancy(occ):
     """Convert occupancy as number of inhabitants currently in house."""
     for i in xrange(len(occ)):
         arr = occ[i]
-        arr[arr < 3] = 1
-        arr[arr == 3] = 0
+        arr[arr < 3] = 1 # active (1) or sleeping (2) are both present =1
+        arr[arr == 3] = 0 # absent (3) =0
     return sum(occ)
 
 
-def simulate_scenarios(n_scen, ndays):
+def simulate_scenarios(n_scen, year, ndays, members):
     """Simulate scenarios of demands during ndays.
 
     Parameters
@@ -24,9 +24,14 @@ def simulate_scenarios(n_scen, ndays):
     n_scen : int
         Number of scenarios to generate
 
+    year : int
+        Year to consider
+        
     ndays : int
         Number of days to consider
 
+    members : str
+        Member list of household
 
     Returns
     -------
@@ -45,8 +50,9 @@ def simulate_scenarios(n_scen, ndays):
     """
 
     nminutes = ndays * 1440 + 1
-    ntenm = ndays * 144
-    family = Household("ex", members=["FTE"])
+    ntenm = ndays * 144 + 1
+       
+    family = Household("ex", members=members)
 
     # define arrays storing the scenarios:
     elec = np.zeros((n_scen, nminutes))
@@ -55,11 +61,15 @@ def simulate_scenarios(n_scen, ndays):
 
     for i in xrange(n_scen):
         print "Generate scenario {}".format(i)
-        family.simulate(2013, ndays)
+        family.simulate(year, ndays)
 
         # aggregate scenarios:
         elec[i, :] = family.P
         mDHW[i, :] = family.mDHW
+        occupancy[i, :] = convert_occupancy(family.occ)
+    
+    result={'elec':elec, 'mDHW':mDHW, 'occupancy':occupancy}
 
-    return elec, mDHW, occupancy
+    return result
 
+result = simulate_scenarios(2, 2020, 366, members=['FTE', 'PTE', 'School'] )

--- a/Data/Appliances.py
+++ b/Data/Appliances.py
@@ -3,7 +3,7 @@ set_appliances = \
   "FridgeFreezer": {
     "frad": 0.46, 
     "cycle_power": 190, 
-    "cal": 0.05302278109276634, 
+    "cal": 0.05348400435732094, 
     "standby_power": 0, 
     "owner": 0.651, 
     "cycle_n": 6115.75932851014, 
@@ -18,7 +18,7 @@ set_appliances = \
   "Hob": {
     "frad": 0.3, 
     "cycle_power": 2400, 
-    "cal": 0.035719693342637734, 
+    "cal": 0.036523596330418226, 
     "standby_power": 1, 
     "owner": 0.463, 
     "cycle_n": 417.902007298679, 
@@ -48,7 +48,7 @@ set_appliances = \
   "DVD": {
     "frad": 0.92, 
     "cycle_power": 33.5521973529143, 
-    "cal": 0.05483103394785327, 
+    "cal": 0.055821331844623616, 
     "standby_power": 2, 
     "owner": 0.896, 
     "cycle_n": 1464.26653737683, 
@@ -63,7 +63,7 @@ set_appliances = \
   "Kettle": {
     "frad": 0.17, 
     "cycle_power": 2000, 
-    "cal": 0.004343036279384075, 
+    "cal": 0.004612679788676307, 
     "standby_power": 1, 
     "owner": 0.975, 
     "cycle_n": 1519.82286616642, 
@@ -78,7 +78,7 @@ set_appliances = \
   "Microwave": {
     "frad": 0, 
     "cycle_power": 1250, 
-    "cal": 0.0075533680233228475, 
+    "cal": 0.008013148873682017, 
     "standby_power": 2, 
     "owner": 0.859, 
     "cycle_n": 94.619322407248, 
@@ -93,7 +93,7 @@ set_appliances = \
   "HiFi": {
     "frad": 0.5, 
     "cycle_power": 100, 
-    "cal": 0.0076866474619492284, 
+    "cal": 0.008005019574356842, 
     "standby_power": 9, 
     "owner": 0.9, 
     "cycle_n": 109.425544999843, 
@@ -107,7 +107,7 @@ set_appliances = \
   }, 
   "bathFlow": {
     "cycle_length": 10, 
-    "cal": 0.013959890338716127, 
+    "cal": 0.01447147553646071, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "shower", 
@@ -118,7 +118,7 @@ set_appliances = \
   "ChestFreezer": {
     "frad": 0.46, 
     "cycle_power": 190, 
-    "cal": 0.06346681125456163, 
+    "cal": 0.06627085372080074, 
     "standby_power": 0, 
     "owner": 0.163, 
     "cycle_n": 6115.75932851014, 
@@ -133,7 +133,7 @@ set_appliances = \
   "Fax": {
     "frad": 0.5, 
     "cycle_power": 37, 
-    "cal": 0.0005413938298533963, 
+    "cal": 0.0005869916079454653, 
     "standby_power": 3, 
     "owner": 0.2, 
     "cycle_n": 197.123588348433, 
@@ -148,7 +148,7 @@ set_appliances = \
   "Printer": {
     "frad": 0.67, 
     "cycle_power": 335.2, 
-    "cal": 0.05980888943100479, 
+    "cal": 0.06347513729112045, 
     "standby_power": 4, 
     "owner": 0.665, 
     "cycle_n": 654.875958011369, 
@@ -163,7 +163,7 @@ set_appliances = \
   "PC": {
     "frad": 0.92, 
     "cycle_power": 140.7, 
-    "cal": 0.07499926963830043, 
+    "cal": 0.08083397129113995, 
     "standby_power": 5, 
     "owner": 0.708, 
     "cycle_n": 449.237984776012, 
@@ -193,7 +193,7 @@ set_appliances = \
   "WasherDryer": {
     "frad": 0.0, 
     "cycle_power": 792.034786057663, 
-    "cal": 0.2887586611722148, 
+    "cal": 0.28709666854255933, 
     "standby_power": 1, 
     "owner": 0.153, 
     "cycle_n": 195.906595865545, 
@@ -208,7 +208,7 @@ set_appliances = \
   "UprightFreezer": {
     "frad": 0.46, 
     "cycle_power": 155, 
-    "cal": 0.0436450754889704, 
+    "cal": 0.04577208372652669, 
     "standby_power": 0, 
     "owner": 0.291, 
     "cycle_n": 6115.75932851014, 
@@ -223,7 +223,7 @@ set_appliances = \
   "Vacuum": {
     "frad": 0.5, 
     "cycle_power": 2000, 
-    "cal": 0.13664095138921212, 
+    "cal": 0.14321421339450868, 
     "standby_power": 0, 
     "owner": 0.937, 
     "cycle_n": 110.367597918536, 
@@ -238,7 +238,7 @@ set_appliances = \
   "Refrigerator": {
     "frad": 0.46, 
     "cycle_power": 110, 
-    "cal": 0.03385193315361484, 
+    "cal": 0.035861772069934156, 
     "standby_power": 0, 
     "owner": 0.43, 
     "cycle_n": 6115.75932851014, 
@@ -252,7 +252,7 @@ set_appliances = \
   }, 
   "shortFlow": {
     "cycle_length": 1, 
-    "cal": 0.04098810282302966, 
+    "cal": 0.042562311913397724, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "Presence", 
@@ -263,7 +263,7 @@ set_appliances = \
   "TV1": {
     "frad": 0.65, 
     "cycle_power": 124, 
-    "cal": 0.05468163455408799, 
+    "cal": 0.056168679073161205, 
     "standby_power": 3, 
     "owner": 0.977, 
     "cycle_n": 1464.26653737683, 
@@ -278,7 +278,7 @@ set_appliances = \
   "MusicPlayer": {
     "frad": 0.5, 
     "cycle_power": 15, 
-    "cal": 0.12567928463364575, 
+    "cal": 0.1298248939973467, 
     "standby_power": 2, 
     "owner": 0.9, 
     "cycle_n": 1212.76285809679, 
@@ -293,7 +293,7 @@ set_appliances = \
   "TV3": {
     "frad": 0.65, 
     "cycle_power": 124, 
-    "cal": 0.05511285694231206, 
+    "cal": 0.06283000905624272, 
     "standby_power": 2, 
     "owner": 0.18, 
     "cycle_n": 1521.49596625218, 
@@ -308,7 +308,7 @@ set_appliances = \
   "TV2": {
     "frad": 0.65, 
     "cycle_power": 124, 
-    "cal": 0.05384932384140438, 
+    "cal": 0.055739364679278376, 
     "standby_power": 3, 
     "owner": 0.58, 
     "cycle_n": 1464.26653737683, 
@@ -322,7 +322,7 @@ set_appliances = \
   }, 
   "mediumFlow": {
     "cycle_length": 1, 
-    "cal": 0.01712974547614407, 
+    "cal": 0.017810482681251995, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "Presence", 
@@ -333,7 +333,7 @@ set_appliances = \
   "Iron": {
     "frad": 0.5, 
     "cycle_power": 1000, 
-    "cal": 0.009365414670544862, 
+    "cal": 0.009646339097045481, 
     "standby_power": 0, 
     "owner": 0.9, 
     "cycle_n": 35.4594692107747, 
@@ -348,7 +348,7 @@ set_appliances = \
   "TumbleDryer": {
     "frad": 0.0, 
     "cycle_power": 2500, 
-    "cal": 0.4932231780194472, 
+    "cal": 0.49474492492582306, 
     "standby_power": 1, 
     "owner": 0.416, 
     "cycle_n": 122.072915738278, 
@@ -363,7 +363,7 @@ set_appliances = \
   "DishWasher": {
     "frad": 0.0, 
     "cycle_power": 1130.61224489796, 
-    "cal": 0.045701393607434415, 
+    "cal": 0.04603964569480809, 
     "standby_power": 0, 
     "owner": 0.335, 
     "cycle_n": 241.476395726831, 
@@ -378,7 +378,7 @@ set_appliances = \
   "TVReceiver": {
     "frad": 0.92, 
     "cycle_power": 26.8237423726735, 
-    "cal": 0.0548252897719791, 
+    "cal": 0.05635113292276207, 
     "standby_power": 15, 
     "owner": 0.934, 
     "cycle_n": 1464.26653737683, 
@@ -392,7 +392,7 @@ set_appliances = \
   }, 
   "showerFlow": {
     "cycle_length": 5, 
-    "cal": 0.01979471557132772, 
+    "cal": 0.0204493968188275, 
     "owner": 0.0, 
     "standby_flow": 0, 
     "activity": "shower", 
@@ -403,7 +403,7 @@ set_appliances = \
   "WashingMachine": {
     "frad": 0.0, 
     "cycle_power": 405.54347826087, 
-    "cal": 0.2523055679005739, 
+    "cal": 0.2632287603579244, 
     "standby_power": 1, 
     "owner": 0.781, 
     "cycle_n": 195.906595865545, 
@@ -418,7 +418,7 @@ set_appliances = \
   "Oven": {
     "frad": 0.17, 
     "cycle_power": 2125, 
-    "cal": 0.01809465246066292, 
+    "cal": 0.019262659189245385, 
     "standby_power": 3, 
     "owner": 0.616, 
     "cycle_n": 219.792801008503, 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ In [example.py](https://github.com/open-ideas/StROBe/blob/master/example.py) you
 
 ## Revision history
 
-**OCt 1, 2020**
+**Oct 22, 2020**
+(See [pull request](https://github.com/open-ideas/StROBe/pull/35) for details.)
+
+- Changed occupancy generation in [`Corpus/residentia.py`](https://github.com/open-ideas/StROBe/blob/master/Corpus/residential.py). Now a typical week is created with all different days (previously all weekdays were the same), which is then copied for the year.
+- Changed way 4h shift is implemented. One extra day is simulated in the front, of which 20 hours are then cut, so that the data starts at midnight of the first day of the year. The last 4h are also cut. This replaces a previous [solution](https://github.com/open-ideas/StROBe/pull/10)  which took the last 4h of the year and put them in the front.
+- Other minor fixes.
+
+**Oct 9, 2020**
 (See [pull request](https://github.com/open-ideas/StROBe/pull/33) for details.)
 
 - Fixed problem with wrong occupancy cluster selection, in [`Corpus/data.py`](https://github.com/open-ideas/StROBe/blob/master/Corpus/data.py#L33). Now all different occupancy patterns should be correctly represented.
@@ -95,7 +102,7 @@ In [example.py](https://github.com/open-ideas/StROBe/blob/master/example.py) you
 **Jun 15, 2018**
 (See [pull request](https://github.com/open-ideas/StROBe/pull/10) for details.)
 
-- Brought last 4 h of resulting time series to the front so that data starts at midnight instead of 4am (which is when the survey statistics begin). This is applied in the `roundUp()` function of [`Corpus/residential.py`](https://github.com/open-ideas/StROBe/blob/63da1fc06db9ebe683a69b879436104f1ffdfa11/Corpus/residential.py#L572-L581).
+- Brought last 4h of resulting time series to the front so that data starts at midnight instead of 4am (which is when the survey statistics begin). This is applied in the `roundUp()` function of [`Corpus/residential.py`](https://github.com/open-ideas/StROBe/blob/63da1fc06db9ebe683a69b879436104f1ffdfa11/Corpus/residential.py#L572-L581).
 - Updated [`Corpus/__calibrate__.py`](https://github.com/open-ideas/StROBe/blob/master/Corpus/__calibrate__.py) file to perform automatically the calibration of `cal` values of appliances, and added check for annual electricity load.
 
 **Sep 28, 2017**
@@ -110,6 +117,14 @@ In [example.py](https://github.com/open-ideas/StROBe/blob/master/example.py) you
 - Fixed the generation of lighting loads, that was on when asleep or away.
 - Fixed the selection of appliances, which selected only less probable devices.
 - Updated paths, data importation and initialization files.
+
+**Mar 13, 2014** 
+
+- First full working version. See [repository](https://github.com/open-ideas/StROBe/tree/84921ca49841b40de53273ed08cbf0f49f849e41) at that point.
+
+**Oct 1, 2013** 
+
+- Initial commit.
 
 ## References
 


### PR DESCRIPTION
This request includes two main components: 
- Occupancy is generated for a typical week (all different days), and then copied for the year
- One extra day is simulated in the front, of which 20h are then cut, so that the data starts at midnight of the first day. This replaces a previous quick-fix which took the last 4h of the year and put them in the front. 

Some minor extra improvements here and there, without impact on operation of Strobe. 